### PR TITLE
handle empty objectId fields by returning a zero value instead of an anonymous decoding error

### DIFF
--- a/bson/primitive/objectid.go
+++ b/bson/primitive/objectid.go
@@ -125,6 +125,11 @@ func (id *ObjectID) UnmarshalJSON(b []byte) error {
 			}
 		}
 
+		if len(str) == 0 {
+			id = &NilObjectID
+			return nil
+		}
+
 		if len(str) != 24 {
 			return fmt.Errorf("cannot unmarshal into an ObjectID, the length must be 12 but it is %d", len(str))
 		}


### PR DESCRIPTION
this maintains the functionality of the community driven drivers, and allows us to decode JSON into a bson format